### PR TITLE
Keep statusline errors visible until manually cleared

### DIFF
--- a/model/statusline_config.go
+++ b/model/statusline_config.go
@@ -126,6 +126,9 @@ func (sc *StatuslineConfig) SetViewStats(stats map[string]StatValue) {
 // is true, the message is dismissed on the next keypress (via DismissAutoHide).
 // Setting a message makes the statusline visible.
 func (sc *StatuslineConfig) SetMessage(text string, level MessageLevel, autoHide bool) {
+	if level == MessageLevelError {
+		autoHide = false
+	}
 	sc.mu.Lock()
 	sc.message = text
 	sc.level = level

--- a/model/statusline_config_test.go
+++ b/model/statusline_config_test.go
@@ -132,6 +132,23 @@ func TestStatuslineConfig_MessageAutoHide(t *testing.T) {
 	}
 }
 
+func TestStatuslineConfig_ErrorMessageDoesNotAutoHide(t *testing.T) {
+	sc := NewStatuslineConfig()
+
+	sc.SetMessage("persistent error", MessageLevelError, true)
+
+	msg, level, autoHide := sc.GetMessage()
+	if msg != "persistent error" {
+		t.Errorf("message = %q, want %q", msg, "persistent error")
+	}
+	if level != MessageLevelError {
+		t.Errorf("level = %q, want %q", level, MessageLevelError)
+	}
+	if autoHide {
+		t.Error("error message should never auto-hide")
+	}
+}
+
 func TestStatuslineConfig_MessageMakesVisible(t *testing.T) {
 	sc := NewStatuslineConfig()
 

--- a/model/statusline_config_test.go
+++ b/model/statusline_config_test.go
@@ -147,6 +147,15 @@ func TestStatuslineConfig_ErrorMessageDoesNotAutoHide(t *testing.T) {
 	if autoHide {
 		t.Error("error message should never auto-hide")
 	}
+
+	if sc.DismissAutoHide() {
+		t.Error("DismissAutoHide() should not dismiss an error message")
+	}
+
+	msg, level, autoHide = sc.GetMessage()
+	if msg != "persistent error" || level != MessageLevelError || autoHide {
+		t.Error("error message should remain unchanged after DismissAutoHide")
+	}
 }
 
 func TestStatuslineConfig_MessageMakesVisible(t *testing.T) {


### PR DESCRIPTION
## Summary
- prevent `MessageLevelError` statusline messages from auto-hiding on next key press
- keep info-level messages behavior unchanged
- add tests to lock in persistent error behavior

Closes #59

## Testing
- `go test ./plugin ./view ./view/taskdetail ./task ./model`
