### PR TITLE
Allow descriptive TIKI IDs beyond fixed 6-char suffix

### DIFF
--- a/task/validation.go
+++ b/task/validation.go
@@ -67,10 +67,18 @@ func ValidatePoints(t *Task) string {
 
 // ValidateDependsOn returns an error message if any dependency ID is malformed.
 func ValidateDependsOn(t *Task) string {
+	invalid := make([]string, 0)
+	seen := make(map[string]struct{})
 	for _, dep := range t.DependsOn {
 		if !IsValidTikiIDFormat(dep) {
-			return fmt.Sprintf("invalid tiki ID format: %s (expected TIKI-XXXXXX)", dep)
+			if _, ok := seen[dep]; !ok {
+				invalid = append(invalid, dep)
+				seen[dep] = struct{}{}
+			}
 		}
+	}
+	if len(invalid) > 0 {
+		return fmt.Sprintf("invalid tiki ID format(s): %s (expected UPPERCASE-PREFIX and identifier, e.g. TIKI-ABC123)", strings.Join(invalid, ", "))
 	}
 	return ""
 }
@@ -113,15 +121,33 @@ func IsValidPoints(points int) bool {
 	return points <= config.GetMaxPoints()
 }
 
-// IsValidTikiIDFormat checks if a string matches the TIKI-XXXXXX format
-// where X is an uppercase alphanumeric character.
+// IsValidTikiIDFormat checks if a string matches an uppercase tiki ID:
+// TIKI-IDENTIFIER, where IDENTIFIER may contain additional '-' separators.
 func IsValidTikiIDFormat(id string) bool {
-	if len(id) != 11 || id[:5] != "TIKI-" {
+	if id == "" || strings.Contains(id, " ") {
 		return false
 	}
-	for _, c := range id[5:] {
-		if (c < 'A' || c > 'Z') && (c < '0' || c > '9') {
+
+	parts := strings.Split(id, "-")
+	if len(parts) < 2 {
+		return false
+	}
+	if parts[0] != "TIKI" {
+		return false
+	}
+
+	for i, p := range parts {
+		if p == "" {
 			return false
+		}
+		for _, c := range p {
+			if (c < 'A' || c > 'Z') && (c < '0' || c > '9') {
+				return false
+			}
+		}
+		// Prefix is already validated as TIKI; remaining segments use uppercase alnum.
+		if i == 0 {
+			continue
 		}
 	}
 	return true

--- a/task/validation.go
+++ b/task/validation.go
@@ -78,7 +78,7 @@ func ValidateDependsOn(t *Task) string {
 		}
 	}
 	if len(invalid) > 0 {
-		return fmt.Sprintf("invalid tiki ID format(s): %s (expected UPPERCASE-PREFIX and identifier, e.g. TIKI-ABC123)", strings.Join(invalid, ", "))
+		return fmt.Sprintf("invalid tiki ID format(s): %s (expected TIKI-SEGMENT[-SEGMENT...], e.g. TIKI-ABC123)", strings.Join(invalid, ", "))
 	}
 	return ""
 }

--- a/task/validation_test.go
+++ b/task/validation_test.go
@@ -151,10 +151,10 @@ func TestValidateDependsOn(t *testing.T) {
 		{"empty dependsOn", &Task{DependsOn: nil}, false},
 		{"valid single dependency", &Task{DependsOn: []string{"TIKI-ABC123"}}, false},
 		{"valid multiple dependencies", &Task{DependsOn: []string{"TIKI-ABC123", "TIKI-DEF456"}}, false},
+		{"valid long dependency", &Task{DependsOn: []string{"TIKI-THEMING"}}, false},
 		{"invalid format - lowercase", &Task{DependsOn: []string{"tiki-abc123"}}, true},
 		{"invalid format - wrong prefix", &Task{DependsOn: []string{"TASK-ABC123"}}, true},
-		{"invalid format - too short", &Task{DependsOn: []string{"TIKI-ABC"}}, true},
-		{"invalid format - too long", &Task{DependsOn: []string{"TIKI-ABC1234"}}, true},
+		{"valid shorter identifier", &Task{DependsOn: []string{"TIKI-ABC"}}, false},
 		{"invalid format - special chars", &Task{DependsOn: []string{"TIKI-ABC12!"}}, true},
 		{"mixed valid and invalid", &Task{DependsOn: []string{"TIKI-ABC123", "bad-id"}}, true},
 	}
@@ -282,11 +282,15 @@ func TestIsValidTikiIDFormat(t *testing.T) {
 	}{
 		{"TIKI-ABC123", true},
 		{"TIKI-000000", true},
+		{"TIKI-THEMING", true},
 		{"tiki-abc123", false},
-		{"TASK-ABC123", false},
-		{"TIKI-ABC", false},
-		{"TIKI-ABC1234", false},
+		{"PROJ-FEATURE1", false},
+		{"TIKI-ABC", true},
+		{"TIKI-ABC1234", true},
 		{"TIKI-ABC12!", false},
+		{"TIKI--ABC123", false},
+		{"TIKI ABC123", false},
+		{"NOHYPHEN", false},
 	}
 
 	for _, tt := range tests {

--- a/view/taskdetail/content_provider.go
+++ b/view/taskdetail/content_provider.go
@@ -36,7 +36,8 @@ func (p *taskDescriptionProvider) FetchContent(elem nav.NavElement) (string, err
 	return p.fileHTTP.FetchContent(elem)
 }
 
-// looksLikeTikiID checks if a URL looks like a tiki ID (TIKI-XXXXXX, case-insensitive).
+// looksLikeTikiID checks if a URL looks like a tiki ID:
+// TIKI-SEGMENT[-SEGMENT...], case-insensitive input, uppercase alnum segments.
 func looksLikeTikiID(url string) bool {
 	return taskpkg.IsValidTikiIDFormat(strings.ToUpper(strings.TrimSpace(url)))
 }

--- a/view/taskdetail/content_provider.go
+++ b/view/taskdetail/content_provider.go
@@ -38,19 +38,7 @@ func (p *taskDescriptionProvider) FetchContent(elem nav.NavElement) (string, err
 
 // looksLikeTikiID checks if a URL looks like a tiki ID (TIKI-XXXXXX, case-insensitive).
 func looksLikeTikiID(url string) bool {
-	if len(url) != 11 {
-		return false
-	}
-	upper := strings.ToUpper(url)
-	if upper[:5] != "TIKI-" {
-		return false
-	}
-	for _, c := range upper[5:] {
-		if (c < 'A' || c > 'Z') && (c < '0' || c > '9') {
-			return false
-		}
-	}
-	return true
+	return taskpkg.IsValidTikiIDFormat(strings.ToUpper(strings.TrimSpace(url)))
 }
 
 // formatTaskAsMarkdown renders a task as a readable markdown document.

--- a/view/taskdetail/content_provider_test.go
+++ b/view/taskdetail/content_provider_test.go
@@ -19,9 +19,10 @@ func TestLooksLikeTikiID(t *testing.T) {
 		{"Tiki-AbC123", true},
 		{"TIKI-ZZZZZZ", true},
 		{"TIKI-000000", true},
-		{"TIKI-ABC12", false},   // too short
-		{"TIKI-ABC1234", false}, // too long
+		{"TIKI-ABC12", true},
+		{"TIKI-ABC1234", true},
 		{"JIRA-ABC123", false},
+		{"PROJ-FEATURE-1", false},
 		{"tiki-abc12!", false},
 		{"", false},
 		{"not-a-tiki", false},


### PR DESCRIPTION
## Summary
- relax TIKI ID validation from strict `TIKI-XXXXXX` to flexible uppercase `TIKI-*` segments
- improve dependency validation to report all invalid IDs in one error
- reuse the same ID validation for task link resolution in task detail content provider

Closes #39

## Testing
- `go test ./plugin ./view ./view/taskdetail ./task ./model`
