### PR TITLE
add INDEX_NAV and INCLUDE tags to doki file fetcher

### DIFF
--- a/.doc/doki/doc/doki-index-tags.md
+++ b/.doc/doki/doc/doki-index-tags.md
@@ -1,0 +1,40 @@
+# doki index tags
+
+doki file fetcher supports three HTML comment tags that are processed in memory at load time. The file on disk is never modified.
+
+Tags are only active in plugins with `fetcher: file`.
+
+## INDEX_NAV
+
+```
+<!-- INDEX_NAV -->
+```
+
+Replaced with a flat markdown list of every `index.md` found recursively under the directory of the current file. Each entry links to the sub-index using a path relative to the current file. The H1 heading of each sub-index is used as the link label; the directory name is used as fallback when no H1 exists.
+
+Depth is shown visually through leading spaces in the link label — no nested markdown list structure is created.
+
+Example output for a docs root with `infrastructure/` and `infrastructure/network/` subdirectories:
+
+```markdown
+- [Infrastructure](infrastructure/index.md)
+- [  Network](infrastructure/network/index.md)
+```
+
+Subdirectories without an `index.md` are silently skipped.
+
+## INCLUDE
+
+```
+<!-- INCLUDE:path/to/file.md -->
+```
+
+Replaced with the full content of the referenced file. The path is relative to the current file's directory. Relative links inside the included content are rewritten to remain valid from the including file's location. Tags inside the included file are **not** processed.
+
+## INCLUDE_RECURSIVE
+
+```
+<!-- INCLUDE_RECURSIVE:path/to/file.md -->
+```
+
+Same as `INCLUDE` but also processes `INDEX_NAV`, `INCLUDE`, and `INCLUDE_RECURSIVE` tags found inside the included file. Cycle detection prevents infinite loops — if a file has already been visited in the current include chain it is silently skipped.

--- a/.doc/doki/doc/index.md
+++ b/.doc/doki/doc/index.md
@@ -14,3 +14,4 @@
 - [Recipes](ideas/plugins.md)
 - [Triggers](ideas/triggers.md)
 - [Workflow format versions](workflow-format.md)
+- [doki index tags](doki-index-tags.md)

--- a/internal/viewer/markdown_viewer.go
+++ b/internal/viewer/markdown_viewer.go
@@ -13,6 +13,7 @@ import (
 	navtview "github.com/boolean-maybe/navidown/navidown/tview"
 	"github.com/boolean-maybe/tiki/config"
 	"github.com/boolean-maybe/tiki/util"
+	"github.com/boolean-maybe/tiki/view/dokiindex"
 	"github.com/boolean-maybe/tiki/view/markdown"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -56,6 +57,8 @@ func Run(input InputSpec) error {
 	content, sourcePath, err := loadInitialContent(input, provider)
 	if err != nil {
 		content = markdown.FormatErrorContent(err)
+	} else {
+		content = dokiindex.InjectTags(content, sourcePath)
 	}
 
 	if sourcePath != "" {
@@ -125,6 +128,8 @@ func refreshContent(app *tview.Application, md *markdown.NavigableMarkdown, prov
 	content, err := provider.FetchContent(nav.NavElement{URL: srcPath})
 	if err != nil {
 		content = markdown.FormatErrorContent(err)
+	} else {
+		content = dokiindex.InjectTags(content, srcPath)
 	}
 
 	// one-shot before-draw to get the screen for Kitty image purge

--- a/view/doki_plugin_view.go
+++ b/view/doki_plugin_view.go
@@ -8,6 +8,7 @@ import (
 	"github.com/boolean-maybe/tiki/controller"
 	"github.com/boolean-maybe/tiki/model"
 	"github.com/boolean-maybe/tiki/plugin"
+	"github.com/boolean-maybe/tiki/view/dokiindex"
 	"github.com/boolean-maybe/tiki/view/markdown"
 
 	"github.com/boolean-maybe/navidown/loaders"
@@ -74,6 +75,10 @@ func (dv *DokiView) build() {
 		sourcePath, _ = nav.ResolveMarkdownPath(dv.pluginDef.URL, "", searchRoots)
 		if sourcePath == "" {
 			sourcePath = dv.pluginDef.URL
+		}
+
+		if err == nil {
+			content = dokiindex.InjectTags(content, sourcePath)
 		}
 
 		dv.md = markdown.NewNavigableMarkdown(markdown.NavigableMarkdownConfig{

--- a/view/dokiindex/gen.go
+++ b/view/dokiindex/gen.go
@@ -1,0 +1,177 @@
+package dokiindex
+
+import (
+	"bufio"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var (
+	reIndexNav         = regexp.MustCompile(`<!--\s*INDEX_NAV\s*-->`)
+	reInclude          = regexp.MustCompile(`<!--\s*INCLUDE:(.+?)\s*-->`)
+	reIncludeRecursive = regexp.MustCompile(`<!--\s*INCLUDE_RECURSIVE:(.+?)\s*-->`)
+	reMdLink           = regexp.MustCompile(`(!?\[[^\]]*\])\(([^)]+)\)`)
+)
+
+// InjectTags processes INDEX_NAV, INCLUDE, and INCLUDE_RECURSIVE HTML comment tags
+// in content, returning the result. filePath must be the absolute path of the file
+// whose content is being processed; it is used as the base for resolving relative paths.
+// Returns content unchanged when filePath is empty or no comment tags are present.
+func InjectTags(content, filePath string) string {
+	if filePath == "" || !strings.Contains(content, "<!--") {
+		return content
+	}
+	return process(content, filePath, map[string]bool{filePath: true})
+}
+
+func process(content, filePath string, visited map[string]bool) string {
+	baseDir := filepath.Dir(filePath)
+
+	content = reIndexNav.ReplaceAllStringFunc(content, func(_ string) string {
+		nav := buildIndexNav(baseDir)
+		slog.Debug("dokiindex: injected INDEX_NAV", "file", filePath, "entries", strings.Count(nav, "\n"))
+		return nav
+	})
+
+	content = reIncludeRecursive.ReplaceAllStringFunc(content, func(match string) string {
+		m := reIncludeRecursive.FindStringSubmatch(match)
+		if len(m) < 2 {
+			return match
+		}
+		target := filepath.Join(baseDir, strings.TrimSpace(m[1]))
+		if visited[target] {
+			slog.Warn("dokiindex: cycle detected, skipping INCLUDE_RECURSIVE", "target", target, "from", filePath)
+			return ""
+		}
+		data, err := os.ReadFile(target)
+		if err != nil {
+			slog.Warn("dokiindex: INCLUDE_RECURSIVE target not found", "target", target, "from", filePath)
+			return ""
+		}
+		newVisited := make(map[string]bool, len(visited)+1)
+		for k := range visited {
+			newVisited[k] = true
+		}
+		newVisited[target] = true
+		embedded := process(string(data), target, newVisited)
+		return rewriteLinks(embedded, baseDir, filepath.Dir(target))
+	})
+
+	content = reInclude.ReplaceAllStringFunc(content, func(match string) string {
+		m := reInclude.FindStringSubmatch(match)
+		if len(m) < 2 {
+			return match
+		}
+		target := filepath.Join(baseDir, strings.TrimSpace(m[1]))
+		data, err := os.ReadFile(target)
+		if err != nil {
+			slog.Warn("dokiindex: INCLUDE target not found", "target", target, "from", filePath)
+			return ""
+		}
+		return rewriteLinks(string(data), baseDir, filepath.Dir(target))
+	})
+
+	return content
+}
+
+// buildIndexNav walks baseDir recursively and returns a nested markdown list
+// of all index.md files found in subdirectories, using the H1 heading as the
+// link label and falling back to the directory name.
+func buildIndexNav(baseDir string) string {
+	type entry struct {
+		relPath string
+		depth   int
+		label   string
+	}
+
+	var entries []entry
+
+	filepath.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error { //nolint:errcheck
+		if err != nil || !d.IsDir() || path == baseDir {
+			return nil
+		}
+		indexPath := filepath.Join(path, "index.md")
+		if _, err := os.Stat(indexPath); err != nil {
+			return nil
+		}
+		rel, _ := filepath.Rel(baseDir, indexPath)
+		slashRel := filepath.ToSlash(rel)
+		depth := strings.Count(filepath.ToSlash(filepath.Dir(rel)), "/")
+		label := extractH1(indexPath)
+		if label == "" {
+			label = filepath.Base(path)
+		}
+		entries = append(entries, entry{relPath: slashRel, depth: depth, label: label})
+		return nil
+	})
+
+	var sb strings.Builder
+	for _, e := range entries {
+		fmt.Fprintf(&sb, "- [%s%s](%s)\n", strings.Repeat("  ", e.depth), e.label, e.relPath)
+	}
+	return sb.String()
+}
+
+func extractH1(filePath string) string {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "# ") {
+			return strings.TrimPrefix(line, "# ")
+		}
+	}
+	return ""
+}
+
+// rewriteLinks rewrites relative markdown links in content from paths relative
+// to includedDir to paths relative to includingDir, so links remain valid after
+// the content is embedded in a file at a different location.
+func rewriteLinks(content, includingDir, includedDir string) string {
+	if includingDir == includedDir {
+		return content
+	}
+	return reMdLink.ReplaceAllStringFunc(content, func(match string) string {
+		m := reMdLink.FindStringSubmatch(match)
+		if len(m) < 3 {
+			return match
+		}
+		linkText, url := m[1], m[2]
+		if isAbsoluteURL(url) {
+			return match
+		}
+		urlPath, fragment := splitFragment(url)
+		if urlPath == "" {
+			return match
+		}
+		abs := filepath.Join(includedDir, urlPath)
+		rel, err := filepath.Rel(includingDir, abs)
+		if err != nil {
+			return match
+		}
+		return fmt.Sprintf("%s(%s%s)", linkText, filepath.ToSlash(rel), fragment)
+	})
+}
+
+func isAbsoluteURL(url string) bool {
+	return strings.HasPrefix(url, "http://") ||
+		strings.HasPrefix(url, "https://") ||
+		strings.HasPrefix(url, "/") ||
+		strings.HasPrefix(url, "#")
+}
+
+func splitFragment(url string) (path, fragment string) {
+	if idx := strings.Index(url, "#"); idx >= 0 {
+		return url[:idx], url[idx:]
+	}
+	return url, ""
+}

--- a/view/dokiindex/gen_test.go
+++ b/view/dokiindex/gen_test.go
@@ -1,0 +1,269 @@
+package dokiindex
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// scaffold creates a temp directory tree from a map of relative path → content.
+func scaffold(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for rel, content := range files {
+		abs := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(abs), err)
+		}
+		if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", abs, err)
+		}
+	}
+	return root
+}
+
+func TestInjectTags_NoTags(t *testing.T) {
+	content := "# Hello\n\nNo tags here."
+	got := InjectTags(content, "/some/file.md")
+	if got != content {
+		t.Errorf("expected unchanged content, got %q", got)
+	}
+}
+
+func TestInjectTags_EmptyFilePath(t *testing.T) {
+	content := "<!-- INDEX_NAV -->"
+	got := InjectTags(content, "")
+	if got != content {
+		t.Errorf("expected unchanged content with empty filePath, got %q", got)
+	}
+}
+
+func TestIndexNav_Basic(t *testing.T) {
+	root := scaffold(t, map[string]string{
+		"index.md":           "# Root\n\n<!-- INDEX_NAV -->\n",
+		"alpha/index.md":     "# Alpha\n\nAlpha content.\n",
+		"beta/index.md":      "# Beta\n\nBeta content.\n",
+		"beta/sub/index.md":  "# Sub\n\nSub content.\n",
+	})
+
+	content, _ := os.ReadFile(filepath.Join(root, "index.md"))
+	got := InjectTags(string(content), filepath.Join(root, "index.md"))
+
+	wantLines := []string{
+		"- [Alpha](alpha/index.md)",
+		"- [Beta](beta/index.md)",
+		"- [  Sub](beta/sub/index.md)",
+	}
+	for _, line := range wantLines {
+		if !strings.Contains(got, line) {
+			t.Errorf("missing line %q in output:\n%s", line, got)
+		}
+	}
+}
+
+func TestIndexNav_OrderIsHierarchical(t *testing.T) {
+	root := scaffold(t, map[string]string{
+		"index.md":                  "<!-- INDEX_NAV -->",
+		"external/index.md":         "# External\n",
+		"external/friends/index.md": "# Friends\n",
+		"cheat/index.md":            "# Cheat\n",
+	})
+
+	got := InjectTags("<!-- INDEX_NAV -->", filepath.Join(root, "index.md"))
+
+	cheatPos := strings.Index(got, "Cheat")
+	externalPos := strings.Index(got, "External")
+	friendsPos := strings.Index(got, "Friends")
+
+	if cheatPos < 0 || externalPos < 0 || friendsPos < 0 {
+		t.Fatalf("missing entries in output:\n%s", got)
+	}
+	if cheatPos > externalPos {
+		t.Errorf("expected Cheat before External (alphabetical top-level order)")
+	}
+	if externalPos > friendsPos {
+		t.Errorf("expected External before Friends (parent before child)")
+	}
+}
+
+func TestIndexNav_FallbackToDirectoryName(t *testing.T) {
+	root := scaffold(t, map[string]string{
+		"index.md":        "<!-- INDEX_NAV -->",
+		"nosection/index.md": "No heading here.\n",
+	})
+
+	got := InjectTags("<!-- INDEX_NAV -->", filepath.Join(root, "index.md"))
+	if !strings.Contains(got, "nosection") {
+		t.Errorf("expected directory name fallback 'nosection' in output:\n%s", got)
+	}
+}
+
+func TestIndexNav_NoSubdirs(t *testing.T) {
+	root := scaffold(t, map[string]string{
+		"index.md": "<!-- INDEX_NAV -->",
+		"page.md":  "# Page\n",
+	})
+
+	got := InjectTags("<!-- INDEX_NAV -->", filepath.Join(root, "index.md"))
+	// Tag should be replaced with empty string (no sub-index files found)
+	if strings.Contains(got, "<!--") {
+		t.Errorf("tag should be replaced, got:\n%s", got)
+	}
+}
+
+func TestInclude_Basic(t *testing.T) {
+	root := scaffold(t, map[string]string{
+		"index.md":  "Before\n<!-- INCLUDE:snippet.md -->\nAfter\n",
+		"snippet.md": "# Snippet\n\nIncluded content.\n",
+	})
+
+	content, _ := os.ReadFile(filepath.Join(root, "index.md"))
+	got := InjectTags(string(content), filepath.Join(root, "index.md"))
+
+	if !strings.Contains(got, "Included content.") {
+		t.Errorf("expected included content in output:\n%s", got)
+	}
+	if !strings.Contains(got, "Before") || !strings.Contains(got, "After") {
+		t.Errorf("expected surrounding content preserved:\n%s", got)
+	}
+	if strings.Contains(got, "<!--") {
+		t.Errorf("tag should be replaced:\n%s", got)
+	}
+}
+
+func TestInclude_MissingFile(t *testing.T) {
+	root := scaffold(t, map[string]string{
+		"index.md": "<!-- INCLUDE:missing.md -->",
+	})
+
+	got := InjectTags("<!-- INCLUDE:missing.md -->", filepath.Join(root, "index.md"))
+	// Missing file: tag replaced with empty string, no panic
+	if strings.Contains(got, "<!--") {
+		t.Errorf("tag should be replaced even for missing file:\n%s", got)
+	}
+}
+
+func TestInclude_LinkRewrite(t *testing.T) {
+	root := scaffold(t, map[string]string{
+		"index.md":         "<!-- INCLUDE:sub/notes.md -->",
+		"sub/notes.md":     "See [this](other.md) and [that](../top.md).\n",
+		"sub/other.md":     "",
+		"top.md":           "",
+	})
+
+	got := InjectTags("<!-- INCLUDE:sub/notes.md -->", filepath.Join(root, "index.md"))
+
+	if !strings.Contains(got, "[this](sub/other.md)") {
+		t.Errorf("expected relative link rewritten to sub/other.md:\n%s", got)
+	}
+	if !strings.Contains(got, "[that](top.md)") {
+		t.Errorf("expected relative link rewritten to top.md:\n%s", got)
+	}
+}
+
+func TestInclude_AbsoluteLinksUnchanged(t *testing.T) {
+	root := scaffold(t, map[string]string{
+		"index.md":     "<!-- INCLUDE:sub/notes.md -->",
+		"sub/notes.md": "[ext](https://example.com) [anchor](#heading)\n",
+	})
+
+	got := InjectTags("<!-- INCLUDE:sub/notes.md -->", filepath.Join(root, "index.md"))
+
+	if !strings.Contains(got, "https://example.com") {
+		t.Errorf("expected absolute URL preserved:\n%s", got)
+	}
+	if !strings.Contains(got, "#heading") {
+		t.Errorf("expected anchor link preserved:\n%s", got)
+	}
+}
+
+func TestInclude_NoRecursion(t *testing.T) {
+	// INCLUDE (non-recursive) should NOT expand tags inside the included file
+	root := scaffold(t, map[string]string{
+		"index.md":   "<!-- INCLUDE:a.md -->",
+		"a.md":       "<!-- INCLUDE:b.md -->",
+		"b.md":       "B content\n",
+	})
+
+	got := InjectTags("<!-- INCLUDE:a.md -->", filepath.Join(root, "index.md"))
+
+	// a.md's content is included, but its INCLUDE tag should NOT be expanded
+	if strings.Contains(got, "B content") {
+		t.Errorf("INCLUDE should not recurse into nested tags, got:\n%s", got)
+	}
+	if !strings.Contains(got, "<!-- INCLUDE:b.md -->") {
+		t.Errorf("nested INCLUDE tag should be preserved as literal text:\n%s", got)
+	}
+}
+
+func TestIncludeRecursive_Expands(t *testing.T) {
+	root := scaffold(t, map[string]string{
+		"index.md": "<!-- INCLUDE_RECURSIVE:a.md -->",
+		"a.md":     "A\n<!-- INCLUDE:b.md -->\n",
+		"b.md":     "B content\n",
+	})
+
+	got := InjectTags("<!-- INCLUDE_RECURSIVE:a.md -->", filepath.Join(root, "index.md"))
+
+	if !strings.Contains(got, "B content") {
+		t.Errorf("INCLUDE_RECURSIVE should expand nested INCLUDE tags:\n%s", got)
+	}
+}
+
+func TestIncludeRecursive_CycleDetection(t *testing.T) {
+	root := scaffold(t, map[string]string{
+		"index.md": "<!-- INCLUDE_RECURSIVE:a.md -->",
+		"a.md":     "A\n<!-- INCLUDE_RECURSIVE:index.md -->\n",
+	})
+
+	// Should not infinite loop or panic
+	got := InjectTags("<!-- INCLUDE_RECURSIVE:a.md -->", filepath.Join(root, "index.md"))
+
+	if strings.Contains(got, "<!--") {
+		// Cycle should be silently dropped, not re-emitted as a tag
+		t.Errorf("cycle should be silently skipped:\n%s", got)
+	}
+}
+
+func TestRewriteLinks_SameDir(t *testing.T) {
+	content := "[link](file.md)"
+	got := rewriteLinks(content, "/a/b", "/a/b")
+	if got != content {
+		t.Errorf("same dir should return content unchanged, got %q", got)
+	}
+}
+
+func TestRewriteLinks_ParentToChild(t *testing.T) {
+	content := "[link](other.md)"
+	got := rewriteLinks(content, "/a", "/a/sub")
+	if got != "[link](sub/other.md)" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRewriteLinks_WithFragment(t *testing.T) {
+	content := "[link](page.md#section)"
+	got := rewriteLinks(content, "/a", "/a/sub")
+	if got != "[link](sub/page.md#section)" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractH1(t *testing.T) {
+	root := scaffold(t, map[string]string{
+		"a.md": "Some preamble\n# My Title\nContent\n",
+		"b.md": "## Not H1\nContent\n",
+		"c.md": "# First\n# Second\n",
+	})
+
+	if got := extractH1(filepath.Join(root, "a.md")); got != "My Title" {
+		t.Errorf("a.md: got %q", got)
+	}
+	if got := extractH1(filepath.Join(root, "b.md")); got != "" {
+		t.Errorf("b.md: expected empty, got %q", got)
+	}
+	if got := extractH1(filepath.Join(root, "c.md")); got != "First" {
+		t.Errorf("c.md: expected first H1, got %q", got)
+	}
+}


### PR DESCRIPTION
Adds three in-memory content tags processed at load time for doki plugins using fetcher: file. No files are modified on disk.

- `<!-- INDEX_NAV -->`: replaced with a flat markdown list of all index.md files found recursively under the current file's directory, ordered depth-first, with visual indentation in the link label.
- ` <!-- INCLUDE:path -->`: replaced with the full content of the referenced file; relative links are rewritten to remain valid.
- `<!-- INCLUDE_RECURSIVE:path -->`: same as INCLUDE but also processes tags inside the included file, with cycle detection.


Also added simple wiki entry of how it works.
Assisted-by: Claude:claude-sonnet-4-6